### PR TITLE
🐛 fixed justify space-between

### DIFF
--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -5,12 +5,11 @@
   box-sizing: border-box;
   flex-direction: row;
   flex-wrap: wrap;
-  @include clearfix();
   @include border-box();
 }
 
 .#{$prefix}-row, .#{$prefix}-row:before, .#{$prefix}-row:after {
-  display: flex
+  display: flex;
 }
 
 .#{$prefix}-row-start {

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -4,21 +4,6 @@
   }
 }
 
-@mixin clearfix() {
-  zoom: 1;
-  &:before,
-  &:after {
-    content: " ";
-    display: table;
-  }
-  &:after {
-    clear: both;
-    visibility: hidden;
-    font-size: 0;
-    height: 0;
-  }
-}
-
 @mixin create-grid-columns() {
   @for $i from 1 through $grid-columns {
     $items: ".#{$prefix}-col-#{$i}", ".#{$prefix}-col-xs-#{$i}", ".#{$prefix}-col-sm-#{$i}", ".#{$prefix}-col-md-#{$i}", ".#{$prefix}-col-lg-#{$i}";


### PR DESCRIPTION
When I use justify="space-between" for Row, between the columns appear pseudo-elements. It fixed if you remove the clearfix.

![image](https://user-images.githubusercontent.com/22821859/40770087-640880de-64c2-11e8-9917-c1434d936a18.png)
